### PR TITLE
Support custom door unlock sequences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+/config.js

--- a/config.js.example
+++ b/config.js.example
@@ -1,0 +1,8 @@
+const doorUnlock = {
+  openSequence: 'your-opening-sequence' ,
+  closeSequence: 'your-closing-sequence' ,
+};
+
+module.exports = {
+  doorUnlock ,
+}

--- a/lib/apis/door-unlock.js
+++ b/lib/apis/door-unlock.js
@@ -1,18 +1,33 @@
-var net = require('net')
+const net = require('net')
+const fs = require('fs')
 
 module.exports = class Api {
+  
+    get config() {
+      return {
+        ... {
+          doorUnlock : {
+            openSequence  : '*8*19*20##' ,
+            closeSequence : '*8*20*20##' ,
+          }
+        } ,
+        ... ( fs.existsSync('../../config.js') ? require('../../config.js') : {} ) ,
+      }.doorUnlock;
+    }
+
     path() {
-	    return "/unlock"
+	      return "/unlock"
     }
 
     description() {
-	    return "Unlocks the door"
+  	    return "Unlocks the door"
     }
 
     handle(request, response) {
         this.client = new net.Socket();
-	    this.seq = "*8*19*20##"
+	      this.seq = this.config.openSequence;
         this.client.numberOfRetries = 0;
+        this.client.setNoDelay();
         this.client.setTimeout(3000, () => { console.log('\t\tDL> [timeout connecting to bt_vct]'); this.client.end(); this.client.destroy()} );
         this.client.on('error', (err) => { console.error(err); this.client.destroy() })
         this.client.once('connect', () => { console.log('\t\tDL> [connected]') })
@@ -29,26 +44,26 @@ module.exports = class Api {
     data(data) {
         console.log('\t\tDL <- ' + data)
         if( data == '*#*0##') {
-                if( this.client.numberOfRetries >= 3 ) this.client.destroy()
-                setTimeout( () => {
-                         this.client.numberOfRetries++
-                         console.log("\t\tDL -> " + this.seq)
-                         this.client.write(this.seq)
-                }, 1000 )
+          if( this.client.numberOfRetries >= 3 ) this.client.destroy()
+          setTimeout( () => {
+              this.client.numberOfRetries++
+              console.log("\t\tDL -> " + this.seq)
+              this.client.write(this.seq)
+          }, 1000 )
         } else if( data == '*#*1##')  {
-		if( this.seq == '*8*20*20##' ) {
-			this.client.destroy()
-		} else {
-			setTimeout( () => {
-				if( this.seq === '*8*19*20##' ) {
-					this.seq = '*8*20*20##'
-					console.log("\t\tDL -> + " + this.seq)
-					this.client.write( this.seq )
-				}
-			}, 2000 )
-		}
+            if( this.seq == this.config.closeSequence ) {
+              this.client.destroy()
+            } else {
+              setTimeout( () => {
+                if( this.seq === this.config.openSequence ) {
+                  this.seq = this.config.closeSequence
+                  console.log("\t\tDL -> + " + this.seq)
+                  this.client.write( this.seq )
+                }
+              }, 2000 )
+            }
         } else {
-                console.log('\t\tDL> ?????: ' + data )
+            console.log('\t\tDL> ?????: ' + data )
         }
     }
 }


### PR DESCRIPTION
One of my doors uses sequences '\*8\*19\*213##' and '\*8\*20\*213##'. This change uses an optional config.js file with these custom sequences instead of default ones. If there's no config.js file, fallbacks to '\*8\*19\*20##' and '\*8\*20\*20##', maintaining full backward compatibility.

The config.js can also be used for further customizations.