### PR TITLE
Feature mqtt retain option

### DIFF
--- a/config.js
+++ b/config.js
@@ -23,6 +23,8 @@ const mqtt_config = {
     'password': '',
     // MQTT Topic, will resolve to 'topic/eventname'
     'topic': 'bticino',
+    // If retain is true, the message will be retained as a "last known good" value on the broker
+    'retain': false,
     // Path of mosquitto_pub on the intercom
     'exec_path': '/usr/bin/mosquitto_pub'
 }

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -41,7 +41,7 @@ class MQTT {
 
     #dispatchInternal( topic, msg ) {
         if( config.mqtt_config.enabled && config.mqtt_config.host.length > 0 ) {
-            let cmd = this.cmd + ' -t ' + topic + ' -m "' + msg + '"'
+            let cmd = this.cmd + ( config.mqtt_config.retain ? ' -r' : '' ) + ' -t ' + topic + ' -m "' + msg + '"'
             //console.log("exec: " + cmd)
             try {
                 child_process.exec(cmd, (msg) => {


### PR DESCRIPTION
Added an optional parameter for enabling the retain option in mosquitto_pub. Retain option instructs the broker to keep the last message for each topic and it's very useful.

If there's no retain option in config.js, code will assume a false value.

Tested in my C100X installation and working flawlessly.