### PR TITLE
Feature door unlock menu

### DIFF
--- a/lib/apis/door-unlock.js
+++ b/lib/apis/door-unlock.js
@@ -11,29 +11,27 @@ module.exports = class Api {
     }
 
     handle(request, response, url, q) {
+        response.write("<pre>")
+        response.write("<a href='./unlock?id=default'>Default</a><br/>")
+        if( config.additionalLocks )
+        {
+            for( const lock in config.additionalLocks )
+            {
+                response.write("<a href='./unlock?id=" + lock + "'>" + lock + "</a><br/>")
+            }
+        }
+        response.write("</pre>")
         if( q.id ) {
             let door = config.additionalLocks[q.id];
             if( door ) {
-                openwebnet.run("doorUnlock", door.openSequence, door.closeSequence)
+                openwebnet.run("doorUnlock", door.openSequence, door.closeSequence )
+                response.write("Opened lock: " + q.id + "<br/>")
             } else if( q.id === "default" ) {
                 openwebnet.run("doorUnlock", config.doorUnlock.openSequence, config.doorUnlock.closeSequence)
+                response.write("Opened default lock<br/>")
             } else {
                 console.error("Door with id: " + q.id + " not found.")
             }
-        } else {
-            response.write("<pre>")
-            response.write("<a href='./unlock?id=default'>Default</a><br/>")
-            if( config.additionalLocks )
-            {
-                for( const lock in config.additionalLocks )
-                {
-                    response.write("<a href='./unlock?id=" + lock + "'>" + lock + "</a><br/>")
-                }
-            }
-            response.write("</pre>")
         }
-
-        response.writeHead(200, { "Content-Type": "text/plain" });
-        response.write("DONE\n")
     }
 }

--- a/lib/apis/door-unlock.js
+++ b/lib/apis/door-unlock.js
@@ -15,11 +15,22 @@ module.exports = class Api {
             let door = config.additionalLocks[q.id];
             if( door ) {
                 openwebnet.run("doorUnlock", door.openSequence, door.closeSequence)
+            } else if( q.id === "default" ) {
+                openwebnet.run("doorUnlock", config.doorUnlock.openSequence, config.doorUnlock.closeSequence)
             } else {
                 console.error("Door with id: " + q.id + " not found.")
             }
         } else {
-            openwebnet.run("doorUnlock", config.doorUnlock.openSequence, config.doorUnlock.closeSequence)
+            response.write("<pre>")
+            response.write("<a href='./unlock?id='default'>Default</a><br/>")
+            if( config.additionalLocks )
+            {
+                for( const lock in config.additionalLocks )
+                {
+                    response.write("<a href='./unlock?id='" + lock + "'>" + lock + "</a><br/>")
+                }
+            }
+            response.write("</pre>")
         }
 
         response.writeHead(200, { "Content-Type": "text/plain" });

--- a/lib/apis/door-unlock.js
+++ b/lib/apis/door-unlock.js
@@ -22,12 +22,12 @@ module.exports = class Api {
             }
         } else {
             response.write("<pre>")
-            response.write("<a href='./unlock?id='default'>Default</a><br/>")
+            response.write("<a href='./unlock?id=default'>Default</a><br/>")
             if( config.additionalLocks )
             {
                 for( const lock in config.additionalLocks )
                 {
-                    response.write("<a href='./unlock?id='" + lock + "'>" + lock + "</a><br/>")
+                    response.write("<a href='./unlock?id=" + lock + "'>" + lock + "</a><br/>")
                 }
             }
             response.write("</pre>")


### PR DESCRIPTION
WARNING: breaking change.

When calling /unlock, instead of just unlocking with default code (*8*[19|20]*20##), now shows a menu with the default code as well as any additional locks defined in config.js. Old /unlock behaviour is now /unlock?id=default (that's the breaking change).

Tested successfully in my C100X device.