### PR TITLE
Use new utils.model() function in load.js api

### DIFF
--- a/lib/apis/load.js
+++ b/lib/apis/load.js
@@ -12,8 +12,8 @@ module.exports = class Api {
 
     handle(request, response) {
         response.write("<pre>")
-        response.write("C300X cpu temperature: \n");
-        response.write( utils.temperature()  + "\n\n");
+        response.write( utils.model() + " cpu temperature: \n");
+        response.write( utils.temperature() + "\n\n");
         response.write("Load:\n");
         response.write( utils.load() )
         response.write("</pre>")


### PR DESCRIPTION
Make use of new model() function inside load api, which has "c300x" hardcoded inside it.