### PR TITLE
Add smartphone forwarding controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Supports:
 * Register endpoints to receive doorbell pressed, door locked and door unlocked events
 * Enable/disable voice mail and show the status
 * Enable/disable the ringer and show the status
+* Enable/block smartphone call forwarding and show the status
 * Start dropbear sshd (in case it crashes)
 * Validates scrypted setup
 * Exposes the voicemail videoclips

--- a/config.js
+++ b/config.js
@@ -40,7 +40,13 @@ const mqtt_config = {
     // If retain is true, the message will be retained as a "last known good" value on the broker
     'retain': false,
     // Path of mosquitto_pub on the intercom
-    'exec_path': '/usr/bin/mosquitto_pub'
+    'exec_path': '/usr/bin/mosquitto_pub',
+    // Optional command listener. Keep this disabled unless you want MQTT writes.
+    'enable_smartphone_forwarding_command': false,
+    // Defaults to '<topic>/smartphone_forwarding/set' when left empty
+    'smartphone_forwarding_command_topic': '',
+    // Path of mosquitto_sub on the intercom
+    'sub_exec_path': '/usr/bin/mosquitto_sub'
 }
 
 const sip = {

--- a/config.json.example
+++ b/config.json.example
@@ -9,6 +9,8 @@
     },
     "mqtt_config": {
         "enabled" : true,
-        "host": "192.168.0.2"
+        "host": "192.168.0.2",
+        "enable_smartphone_forwarding_command": false,
+        "smartphone_forwarding_command_topic": "bticino/smartphone_forwarding/set"
     }
 }

--- a/lib/apis/smartphone-forwarding.js
+++ b/lib/apis/smartphone-forwarding.js
@@ -1,0 +1,64 @@
+const openwebnet = require('../openwebnet')
+
+const STATES = {
+    0: 'enabled',
+    1: 'in-house-only',
+    2: 'blocked',
+}
+
+function parseMode(result) {
+    const match = result?.match(/\*#8\*\*37\*([012])##/)
+    return match ? Number(match[1]) : undefined
+}
+
+function actionFromQuery(q) {
+    if (q.enable === 'true' || q.state === 'enabled' || q.state === 'enable') {
+        return 'smartphoneForwardingEnable'
+    }
+    if (q.enable === 'false' || q.block === 'true' || q.state === 'blocked' || q.state === 'block') {
+        return 'smartphoneForwardingBlock'
+    }
+    return 'smartphoneForwardingStatus'
+}
+
+module.exports = class Api {
+    path() {
+        return '/smartphone-forwarding'
+    }
+
+    description() {
+        return 'Enables/disables smartphone call forwarding'
+    }
+
+    handle(request, response, url, q) {
+        if (q.raw === 'true') {
+            response.setHeader('Content-Type', 'application/json; charset=utf-8')
+            const action = actionFromQuery(q)
+            openwebnet.run(action)
+                .then((result) => {
+                    const mode = parseMode(result)
+                    response.end(JSON.stringify({
+                        mode,
+                        state: STATES[mode] || 'unknown',
+                        raw: result,
+                    }))
+                })
+                .catch((e) => {
+                    response.statusCode = 500
+                    response.end(JSON.stringify({ error: e?.message || String(e) }))
+                })
+            return
+        }
+
+        response.write('<pre>')
+        response.write("<a href='./smartphone-forwarding?enable=true'>Enable all smartphone forwarding</a><br/>")
+        response.write("<a href='./smartphone-forwarding?enable=false'>Block all smartphone forwarding</a><br/>")
+        response.write("<a href='./smartphone-forwarding?raw=true'>Raw status</a>")
+        response.write('</pre>')
+
+        const action = actionFromQuery(q)
+        if (action !== 'smartphoneForwardingStatus') {
+            openwebnet.run(action).catch((e) => console.error(e))
+        }
+    }
+}

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -8,17 +8,22 @@ class MQTT {
 
     #api
     #cmd
+    #smartphoneForwardingCommandProcess
+    #smartphoneForwardingCommandBuffer = ''
 
     constructor(api) {
         this.#api = api
-        if( config.mqtt_config.enabled && config.mqtt_config.enable_intercom_status && config.mqtt_config.status_polling_interval > 0 ) {
-            this.#updateStatus()
-        }
         let cmd = config.mqtt_config.exec_path + ' -h ' + config.mqtt_config.host + ' -p ' + config.mqtt_config.port;
         if( config.mqtt_config.username.length > 0 ) {
             cmd += ' -u ' + config.mqtt_config.username + ' -P ' + config.mqtt_config.password
         }
         this.#cmd = cmd;
+        if( config.mqtt_config.enabled && config.mqtt_config.enable_intercom_status && config.mqtt_config.status_polling_interval > 0 ) {
+            this.#updateStatus()
+        }
+        if( config.mqtt_config.enabled && config.mqtt_config.enable_smartphone_forwarding_command ) {
+            this.#subscribeSmartphoneForwardingCommands()
+        }
     }
 
     dispatch(msg) {
@@ -64,6 +69,95 @@ class MQTT {
         }
     }
 
+    #mqttArgs(topic) {
+        const args = ['-h', config.mqtt_config.host, '-p', config.mqtt_config.port.toString(), '-t', topic]
+        if( config.mqtt_config.username.length > 0 ) {
+            args.push('-u', config.mqtt_config.username, '-P', config.mqtt_config.password)
+        }
+        return args
+    }
+
+    #subscribeSmartphoneForwardingCommands() {
+        if( !(config.mqtt_config.enabled && config.mqtt_config.host.length > 0) ) {
+            return
+        }
+        const topic = config.mqtt_config.smartphone_forwarding_command_topic || config.mqtt_config.topic + '/smartphone_forwarding/set'
+        const command = config.mqtt_config.sub_exec_path || '/usr/bin/mosquitto_sub'
+        const args = this.#mqttArgs(topic)
+
+        debug('subscribing to smartphone forwarding commands on topic ' + topic)
+        const child = child_process.spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+        this.#smartphoneForwardingCommandProcess = child
+
+        child.stdout.on('data', (data) => {
+            this.#smartphoneForwardingCommandBuffer += data.toString()
+            const lines = this.#smartphoneForwardingCommandBuffer.split(/\r?\n/)
+            this.#smartphoneForwardingCommandBuffer = lines.pop()
+            lines.forEach((line) => this.#handleSmartphoneForwardingCommand(line))
+        })
+
+        child.stderr.on('data', (data) => {
+            debug('mosquitto_sub stderr: ' + data.toString().trim())
+        })
+
+        child.on('error', (e) => {
+            console.error('Smartphone forwarding MQTT command listener failed: ' + e.message)
+        })
+
+        child.on('close', (code) => {
+            if( this.#smartphoneForwardingCommandProcess !== child ) {
+                return
+            }
+            console.error('Smartphone forwarding MQTT command listener exited: ' + code)
+            setTimeout(() => this.#subscribeSmartphoneForwardingCommands(), 10000)
+        })
+    }
+
+    #handleSmartphoneForwardingCommand(msg) {
+        const payload = msg.trim().toLowerCase()
+        const action = this.#smartphoneForwardingAction(payload)
+        if( !action ) {
+            console.error('Ignoring unsupported smartphone forwarding MQTT payload: ' + msg)
+            return
+        }
+
+        openwebnet.run(action)
+            .then((result) => this.#dispatchSmartphoneForwardingState(result))
+            .catch((e) => console.error(e))
+    }
+
+    #smartphoneForwardingAction(payload) {
+        if( ['enable', 'enabled', 'on', 'true', '0'].includes(payload) ) {
+            return 'smartphoneForwardingEnable'
+        }
+        if( ['block', 'blocked', 'disable', 'disabled', 'off', 'false', '2'].includes(payload) ) {
+            return 'smartphoneForwardingBlock'
+        }
+        return undefined
+    }
+
+    #dispatchSmartphoneForwardingState(result) {
+        const status = this.#parseSmartphoneForwardingStatus(result)
+        if( !status ) {
+            return
+        }
+        this.#dispatchInternal(config.mqtt_config.topic + '/smartphone_forwarding/state', JSON.stringify(status))
+    }
+
+    #parseSmartphoneForwardingStatus(result) {
+        const matches = [...result.matchAll(/\*#8\*\*37\*([012])##/gm)]
+        if( !(matches && matches.length > 0 && matches[0].length > 0) ) {
+            return undefined
+        }
+        const mode = matches[0][1]
+        const states = {
+            '0': 'enabled',
+            '1': 'in-house-only',
+            '2': 'blocked',
+        }
+        return { mode, state: states[mode] || 'unknown' }
+    }
+
     async #updateStatus() {
         if( !(config.mqtt_config.enabled && config.mqtt_config.host.length > 0) ) {
             return
@@ -90,6 +184,17 @@ class MQTT {
         }
 
         status['voicemail_messages'] = utils.voiceMailMessages()
+
+        try {
+            let smartphoneForwardingStatus = await openwebnet.run("smartphoneForwardingStatus")
+            const forwarding = this.#parseSmartphoneForwardingStatus(smartphoneForwardingStatus)
+            if( forwarding ) {
+                status['smartphone_forwarding'] = forwarding
+                this.#dispatchSmartphoneForwardingState(smartphoneForwardingStatus)
+            }
+        } catch(e) {
+            console.error("Error matching smartphone forwarding status")
+        }
 
         this.#dispatchInternal(config.mqtt_config.topic + '/status', JSON.stringify(status) )
         setTimeout( () => this.#updateStatus(), config.mqtt_config.status_polling_interval * 1000 )

--- a/lib/openwebnet.js
+++ b/lib/openwebnet.js
@@ -244,6 +244,15 @@ class OpenWebnet {
     _api_aswmStatus() {
         this.#push("*#8**40##", (arg, command) => { return arg.startsWith('*#8**') }, (arg, command) => { return this.#pass(arg, command) })
     }
+    _api_smartphoneForwardingEnable() {
+        this.#push("*#8**#37*0##", (arg) => { return arg == "*#8**37*0##" }, (arg, command) => this.#pass(arg, command))
+    }
+    _api_smartphoneForwardingBlock() {
+        this.#push("*#8**#37*2##", (arg) => { return arg == "*#8**37*2##" }, (arg, command) => this.#pass(arg, command))
+    }
+    _api_smartphoneForwardingStatus() {
+        this.#push("*#8**37##", (arg) => { return arg == "*#8**37*0##" || arg == "*#8**37*1##" || arg == "*#8**37*2##" }, (arg, command) => this.#pass(arg, command))
+    }
     _api_doorUnlock() {
         this.#push(arguments[1],
             (arg) => {


### PR DESCRIPTION
## Summary
- add OpenWebNet calls for Classe 300X smartphone call forwarding status, enable, and block
- expose a dedicated `/smartphone-forwarding` HTTP endpoint
- add an opt-in MQTT command listener for smartphone forwarding control and state publishing
- list smartphone call forwarding in the API support overview

## Why
The existing `/aswm` endpoint controls answering-machine/voicemail state. Smartphone call forwarding uses OpenWebNet dimension 37 instead:
- status: `*#8**37##`
- enable all: `*#8**#37*0##`
- block all: `*#8**#37*2##`

## Validation
- `node -c config.js lib/apis/smartphone-forwarding.js lib/mqtt.js lib/openwebnet.js`
- `git diff --check upstream/main...HEAD`
- package and lockfile versions verified unchanged at `2024.9.1`
- production and development bundles built with the local Webpack CLI
- privacy scan of `upstream/main...HEAD` for device IPs, credentials, tokens, and private SSH/user values

Note: this PR intentionally excludes the fork-only `2026.5.1` release bump.
